### PR TITLE
fix: support running test with TestSource using ref

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -17392,6 +17392,9 @@ class Connection {
     getTestSuiteExecutionDetails(executionId, allowFailure) {
         return this.get(`/test-suite-executions/${executionId}`, allowFailure);
     }
+    getSourceDetails(id, allowFailure) {
+        return this.get(`/test-sources/${id}`, allowFailure);
+    }
     openLogsSocket(executionId) {
         return this.ws(`/executions/${executionId}/logs/stream`);
     }
@@ -17649,7 +17652,9 @@ const entity = input.test ? new _entities__WEBPACK_IMPORTED_MODULE_8__/* .TestEn
 // Get test details
 _write__WEBPACK_IMPORTED_MODULE_4__/* .header */ .Fs('Obtaining details');
 const details = await entity.get();
-if (!['git', 'git-dir', 'git-file'].includes(details.content?.type) && input.ref) {
+const sourceId = details.source;
+const source = sourceId ? await client.getSourceDetails(sourceId) : null;
+if (input.ref && !['git', 'git-dir', 'git-file'].includes(details.content?.type || source?.type)) {
     _write__WEBPACK_IMPORTED_MODULE_4__/* .critical */ .kq('Git revision provided, but the test is not sourced from Git.');
 }
 // Run test

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -10,7 +10,7 @@ import {
   ConnectionConfig,
   TestDetails,
   TestExecutionData,
-  TestExecutionDetails,
+  TestExecutionDetails, TestSource,
   TestSuiteDetails, TestSuiteExecutionData, TestSuiteExecutionDetails
 } from './types';
 
@@ -131,6 +131,10 @@ export class Connection {
 
   getTestSuiteExecutionDetails(executionId: string, allowFailure?: boolean): Promise<TestSuiteExecutionDetails> {
     return this.get<TestSuiteExecutionDetails>(`/test-suite-executions/${executionId}`, allowFailure);
+  }
+
+  getSourceDetails(id: string, allowFailure?: boolean): Promise<TestSource> {
+    return this.get<TestSource>(`/test-sources/${id}`, allowFailure);
   }
 
   openLogsSocket(executionId: string): WebSocket {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import {parse as parseEnv} from 'dotenv';
 import kleur from 'kleur';
 import * as write from './write';
 import {Connection, resolveConfig} from './connection';
-import {ActionInput, ExecutionStatus} from './types';
+import {ActionInput, ExecutionStatus, TestDetails} from './types';
 import {runningContext} from './config';
 import {TestEntity, TestSuiteEntity} from './entities';
 import {formatVariables} from './utils';
@@ -57,8 +57,10 @@ const entity = input.test ? new TestEntity(client, input.test) : new TestSuiteEn
 
 write.header('Obtaining details');
 const details = await entity.get();
+const sourceId = (details as TestDetails).source;
+const source = sourceId ? await client.getSourceDetails(sourceId) : null;
 
-if (!['git', 'git-dir', 'git-file'].includes(details.content?.type!) && input.ref) {
+if (input.ref && !['git', 'git-dir', 'git-file'].includes(details.content?.type || source?.type!)) {
   write.critical('Git revision provided, but the test is not sourced from Git.');
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,11 @@ export interface Variable {
   };
 }
 
+export interface TestSource {
+  type: string;
+  name: string;
+}
+
 export interface TestDetails {
   executionRequest?: {
     negativeTest?: boolean;
@@ -54,6 +59,7 @@ export interface TestDetails {
   content?: {
     type: string;
   };
+  source?: string;
 }
 
 export interface TestSuiteDetails {


### PR DESCRIPTION
## Changes

- load external `TestSource` when it's used by test

## Fixes

- kubeshop/testkube-run-action#1

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
