### PR TITLE
fix: support log messages within log_message property

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -17469,7 +17469,7 @@ class TestEntity {
                     }
                     try {
                         const dataToJSON = JSON.parse(logData);
-                        const potentialOutput = dataToJSON?.result?.output || dataToJSON?.output;
+                        const potentialOutput = dataToJSON?.result?.output || dataToJSON?.output || dataToJSON?.log_message;
                         if (potentialOutput) {
                             _write__WEBPACK_IMPORTED_MODULE_3__/* .log */ .cM(potentialOutput);
                             if (dataToJSON.status === _types__WEBPACK_IMPORTED_MODULE_2__/* .ExecutionStatus.failed */ .F.failed) {

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -76,7 +76,7 @@ export class TestEntity implements Entity {
           }
           try {
             const dataToJSON = JSON.parse(logData as any);
-            const potentialOutput = dataToJSON?.result?.output || dataToJSON?.output;
+            const potentialOutput = dataToJSON?.result?.output || dataToJSON?.output || dataToJSON?.log_message;
 
             if (potentialOutput) {
               write.log(potentialOutput);


### PR DESCRIPTION
## Changes

- Support `log_message` in the JSON logs

## Fixes

- kubeshop/testkube#3961

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
