### PR TITLE
feat: allow passing Dashboard's URL to provide execution link

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,12 @@ There are different inputs available for tests and test suites, as well as for C
 |    ✓     | `environment`  | The environment ID from Testkube Cloud or Enterprise - it starts with `tkc_env`, you may find it i.e. in the dashboard's URL                                                                                                              |
 |    ✓     | `token`        | API token that has at least a permission to run specific test or test suite. You may read more about [**creating API token**](https://docs.testkube.io/testkube-cloud/organization-management#api-tokens) in Testkube Cloud or Enterprise |
 |    ✗     | `url`          | URL of the Testkube Enterprise instance, if applicable                                                                                                                                                                                    |
+|    ✗     | `dashboardUrl` | URL of the Testkube Enterprise dashboard, if applicable, to display links for the execution                                                                                                                                               |
 
 ### Own instance
 
-| Required | Name  | Description                                                                                          |
-|:--------:|-------|------------------------------------------------------------------------------------------------------|
-|    ✓     | `url` | URL for the API of the own Testkube instance                                                         |
-|    ✗     | `ws`  | Override WebSocket API URL of the own Testkube instance (use it only if auto-detection doesn't work) |
+| Required | Name           | Description                                                                                          |
+|:--------:|----------------|------------------------------------------------------------------------------------------------------|
+|    ✓     | `url`          | URL for the API of the own Testkube instance                                                         |
+|    ✗     | `ws`           | Override WebSocket API URL of the own Testkube instance (use it only if auto-detection doesn't work) |
+|    ✗     | `dashboardUrl` | URL for the Dashboard of the own Testkube instance, to display links for the execution               |

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,14 +5,16 @@ export const instanceAliases: Record<string, string> = {
   'api.testkube.xyz': 'cloud.testkube.xyz',
 };
 
-export const knownInstances: Record<string, {api: string, ws: string}> = {
+export const knownInstances: Record<string, {api: string, ws: string, dashboard: string}> = {
   'cloud.testkube.io': {
     api: 'https://api.testkube.io',
     ws: 'wss://websockets.testkube.io',
+    dashboard: 'https://cloud.testkube.io',
   },
   'cloud.testkube.xyz': {
     api: 'https://api.testkube.xyz',
     ws: 'wss://websockets.testkube.xyz',
+    dashboard: 'https://cloud.testkube.xyz',
   },
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ const input: ActionInput = {
 
   url: getInput('url'),
   ws: getInput('ws'),
+  dashboardUrl: getInput('dashboardUrl'),
 
   organization: getInput('organization'),
   environment: getInput('environment'),
@@ -50,7 +51,8 @@ if (!input.organization && !input.url) {
 
 // Constants
 
-const client = new Connection(await resolveConfig(input));
+const config = await resolveConfig(input);
+const client = new Connection(config);
 const entity = input.test ? new TestEntity(client, input.test) : new TestSuiteEntity(client, input.testSuite!);
 
 // Get test details
@@ -78,6 +80,13 @@ const execution = await entity.schedule({
 });
 
 write.log(`Execution scheduled: ${execution.name} (${execution.id})`);
+if (config.dashboard) {
+  if (input.test) {
+    write.log(`Dashboard URL: ${config.dashboard}/tests/executions/${input.test}/execution/${execution.id}`);
+  } else {
+    write.log(`Dashboard URL: ${config.dashboard}/test-suites/executions/${input.testSuite}/execution/${execution.id}`);
+  }
+}
 
 // Stream logs
 write.header('Attaching to logs');

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface ActionInput {
 
   url?: string;
   ws?: string;
+  dashboardUrl?: string;
 
   organization?: string;
   environment?: string;
@@ -21,6 +22,7 @@ export interface ActionInput {
 export interface ConnectionConfig {
   url: string;
   ws: string;
+  dashboard?: string;
   token?: string;
   cloud: boolean;
 }


### PR DESCRIPTION
## Changes

- allow passing Dashboard's URL to provide execution link (`dashboardUrl`)
- auto-detect it, based on common patterns
  - Cloud instances have it as static configuration
  - `https?://api.XXX.YYY` is replaced to `https?://cloud.XXX.YYY`
  - `https?://XXX.YYY.ZZZ/results/v1` is replaced to `https?://XXX.YYY.ZZZ`

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
